### PR TITLE
feat: add login and account selection screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "RetailPro POS demo in Electron",
-  "main": "main.js",
+  "main": "src/main/main.js",
   "scripts": {
     "start": "electron .",
     "dev": "electron .",
@@ -19,7 +19,7 @@
     "appId": "com.retailpro.app",
     "productName": "RetailPro",
     "files": [
-      "**/*",
+      "src/**/*",
       "!**/*.map",
       "!node_modules/.cache/**"
     ],

--- a/preload.js
+++ b/preload.js
@@ -1,1 +1,0 @@
-// Reserved for future IPC APIs via contextBridge.

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -6,14 +6,14 @@ function createWindow() {
     width: 1280,
     height: 900,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, '../preload/preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
     },
   });
 
   win.setMenuBarVisibility(false);
-  win.loadFile('index.html');
+  win.loadFile(path.join(__dirname, '../renderer/login.html'));
 }
 
 app.whenReady().then(() => {

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -1,0 +1,4 @@
+const { contextBridge } = require('electron');
+const { version } = require('../../package.json');
+
+contextBridge.exposeInMainWorld('appInfo', { version });

--- a/src/renderer/account.html
+++ b/src/renderer/account.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>RetailPro – Select Store</title>
+  <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64,">
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <link href="./styles.css" rel="stylesheet"/>
+</head>
+<body class="bg-neutral-900 text-neutral-200 flex min-h-screen flex-col">
+  <header class="flex items-center justify-between p-4">
+    <div class="flex items-center gap-2">
+      <div class="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--primary-500)] text-white">
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path d="M8.578 8.578a23.92 23.92 0 0 0 0 33.844L24 27 39.422 42.422a23.92 23.92 0 0 0 0-33.844L24 24 8.578 8.578Z" fill="currentColor"/></svg>
+      </div>
+      <h1 class="text-xl font-bold">RetailPro</h1>
+    </div>
+    <button id="themeToggle" class="rounded-full p-2 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-300" title="Toggle theme">
+      <span id="themeIcon" class="block h-5 w-5">🌙</span>
+    </button>
+  </header>
+
+  <main class="flex flex-1 flex-col items-center justify-center px-4">
+    <h2 class="mb-6 text-2xl font-semibold">Select Store / Desk</h2>
+    <div id="storeList" class="grid w-full max-w-md gap-4"></div>
+  </main>
+
+  <footer class="flex items-center justify-between p-4 text-xs">
+    <span id="version"></span>
+    <div id="connectionStatus" class="flex items-center gap-1">
+      <span class="status-dot h-2 w-2 rounded-full"></span>
+      <span class="status-text"></span>
+    </div>
+  </footer>
+
+  <script type="module" src="./account.js"></script>
+</body>
+</html>

--- a/src/renderer/account.js
+++ b/src/renderer/account.js
@@ -1,0 +1,29 @@
+import { loadTheme, setupThemeToggle } from './theme.js';
+import { initConnectionStatus } from './connection.js';
+
+loadTheme();
+setupThemeToggle(document.getElementById('themeToggle'));
+initConnectionStatus(document.getElementById('connectionStatus'));
+
+const versionEl = document.getElementById('version');
+versionEl.textContent = `v${window.appInfo?.version || '1.0.0'}`;
+
+const stores = [
+  { id: 'main', name: 'Main Street Branch' },
+  { id: 'uptown', name: 'Uptown Branch' }
+];
+
+const list = document.getElementById('storeList');
+stores.forEach((s) => {
+  const btn = document.createElement('button');
+  btn.className = 'w-full rounded-lg bg-neutral-800 px-4 py-6 text-lg font-semibold text-neutral-100 hover:bg-neutral-700';
+  btn.textContent = s.name;
+  btn.addEventListener('click', () => {
+    localStorage.setItem('activeStore', s.id);
+    document.body.classList.add('opacity-0');
+    setTimeout(() => {
+      window.location.href = 'index.html';
+    }, 300);
+  });
+  list.appendChild(btn);
+});

--- a/src/renderer/connection.js
+++ b/src/renderer/connection.js
@@ -1,0 +1,18 @@
+export function initConnectionStatus(container) {
+  if (!container) return;
+  const dot = container.querySelector('.status-dot');
+  const text = container.querySelector('.status-text');
+
+  function update() {
+    const online = navigator.onLine;
+    if (dot) {
+      dot.classList.toggle('bg-green-500', online);
+      dot.classList.toggle('bg-red-500', !online);
+    }
+    if (text) text.textContent = online ? 'Online' : 'Offline';
+  }
+
+  window.addEventListener('online', update);
+  window.addEventListener('offline', update);
+  update();
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,21 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Stitch Design – RetailPro</title>
   <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64,">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-  <style type="text/tailwindcss">
-    :root {
-      --primary-500:#3d99f5; --primary-600:#258af3; --neutral-50:#f8fafc; --neutral-100:#f1f5f9;
-      --neutral-200:#e2e8f0; --neutral-300:#cbd5e1; --neutral-400:#94a3b8; --neutral-600:#475569;
-      --neutral-700:#334155; --neutral-800:#1e293b; --neutral-900:#0f172a;
-    }
-    body { font-family: 'Inter', sans-serif; }
-    input[type=number]::-webkit-outer-spin-button,
-    input[type=number]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-    input[type=number] { -moz-appearance: textfield; }
-  </style>
+  <link href="./styles.css" rel="stylesheet"/>
 </head>
 <body class="bg-neutral-900 text-neutral-200">
 <div class="flex h-screen w-full flex-col">
@@ -51,23 +41,27 @@
         </div>
       </div>
 
-      <div class="w-full max-w-xs">
-        <label class="relative block">
-          <span class="sr-only">Search</span>
-          <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-neutral-500">
-            <svg fill="currentColor" height="20" viewBox="0 0 256 256" width="20" xmlns="http://www.w3.org/2000/svg">
-              <path d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"></path>
-            </svg>
-          </span>
-          <input id="searchInput" class="block w-full rounded-md border-neutral-700 bg-neutral-800 py-2 pl-10 pr-3 text-sm placeholder:text-neutral-500 focus:border-[var(--primary-500)] focus:outline-none focus:ring-1 focus:ring-[var(--primary-500)]" placeholder="Search for products..." type="text"/>
-        </label>
-      </div>
+        <div class="w-full max-w-xs">
+          <label class="relative block">
+            <span class="sr-only">Search</span>
+            <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-neutral-500">
+              <svg fill="currentColor" height="20" viewBox="0 0 256 256" width="20" xmlns="http://www.w3.org/2000/svg">
+                <path d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"></path>
+              </svg>
+            </span>
+            <input id="searchInput" class="block w-full rounded-md border-neutral-700 bg-neutral-800 py-2 pl-10 pr-3 text-sm placeholder:text-neutral-500 focus:border-[var(--primary-500)] focus:outline-none focus:ring-1 focus:ring-[var(--primary-500)]" placeholder="Search for products..." type="text"/>
+          </label>
+        </div>
 
-      <button class="relative rounded-full p-2 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-300" title="Notifications">
-        <svg fill="currentColor" height="24" viewBox="0 0 256 256" width="24" xmlns="http://www.w3.org/2000/svg">
-          <path d="M221.8,175.94C216.25,166.38,208,139.33,208,104a80,80,0,1,0-160,0c0,35.34-8.26,62.38-13.81,71.94A16,16,0,0,0,48,200H88.81a40,40,0,0,0,78.38,0H208a16,16,0,0,0,13.8-24.06ZM128,216a24,24,0,0,1-22.62-16h45.24A24,24,0,0,1,128,216ZM48,184c7.7-13.24,16-43.92,16-80a64,64,0,1,1,128,0c0,36.05,8.28,66.73,16,80Z"></path>
-        </svg>
-      </button>
+        <button id="themeToggle" class="rounded-full p-2 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-300" title="Toggle theme">
+          <span id="themeIcon" class="block h-5 w-5">🌙</span>
+        </button>
+
+        <button class="relative rounded-full p-2 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-300" title="Notifications">
+          <svg fill="currentColor" height="24" viewBox="0 0 256 256" width="24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M221.8,175.94C216.25,166.38,208,139.33,208,104a80,80,0,1,0-160,0c0,35.34-8.26,62.38-13.81,71.94A16,16,0,0,0,48,200H88.81a40,40,0,0,0,78.38,0H208a16,16,0,0,0,13.8-24.06ZM128,216a24,24,0,0,1-22.62-16h45.24A24,24,0,0,1,128,216ZM48,184c7.7-13.24,16-43.92,16-80a64,64,0,1,1,128,0c0,36.05,8.28,66.73,16,80Z"></path>
+          </svg>
+        </button>
       <div class="h-10 w-10 rounded-full bg-cover bg-center" style='background-image:url("https://lh3.googleusercontent.com/aida-public/AB6AXuCA6nwVsDM07YmwHScnzsedGz01HAZf3Jw-68UTeg_G49xpPkUb-V9UPf1EvTvRKSpEzPeI5yaofzmRsraViFovCKn2LWtkIS_-llqYD3jJI_awi5uwZp5GN3bO3u18MMJqDcpzQQAmST0s_W3f37zxFdJb_em5hdRcRujprsbw95_DR_b0UZnCcNUf7qi1KfI4f0y_vqyyA1vMJ0uXD4WGIsCJEgYdXfu1pWjbMFAgAE6rZjEkhaJ3_LVBNvMh_kj-CXI-kXTDuCac");'></div>
     </div>
   </header>
@@ -149,6 +143,6 @@
   </footer>
 </div>
 
-<script src="./renderer.js"></script>
+<script type="module" src="./renderer.js"></script>
 </body>
 </html>

--- a/src/renderer/login.html
+++ b/src/renderer/login.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>RetailPro – Sign In</title>
+  <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64,">
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <link href="./styles.css" rel="stylesheet"/>
+</head>
+<body class="bg-neutral-900 text-neutral-200 flex min-h-screen flex-col">
+  <header class="flex items-center justify-between p-4">
+    <div class="flex items-center gap-2">
+      <div class="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--primary-500)] text-white">
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path d="M8.578 8.578a23.92 23.92 0 0 0 0 33.844L24 27 39.422 42.422a23.92 23.92 0 0 0 0-33.844L24 24 8.578 8.578Z" fill="currentColor"/></svg>
+      </div>
+      <h1 class="text-xl font-bold">RetailPro</h1>
+    </div>
+    <button id="themeToggle" class="rounded-full p-2 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-300" title="Toggle theme">
+      <span id="themeIcon" class="block h-5 w-5">🌙</span>
+    </button>
+  </header>
+
+  <main class="flex flex-1 flex-col items-center justify-center px-4">
+    <form id="loginForm" class="w-full max-w-sm space-y-4">
+      <div>
+        <label for="email" class="mb-1 block text-sm font-medium">Email or Phone</label>
+        <input id="email" type="text" required class="w-full rounded-md border-neutral-700 bg-neutral-800 px-3 py-3 text-sm focus:border-[var(--primary-500)] focus:ring-[var(--primary-500)]"/>
+      </div>
+      <div>
+        <label for="password" class="mb-1 block text-sm font-medium">Password</label>
+        <div class="relative">
+          <input id="password" type="password" required class="w-full rounded-md border-neutral-700 bg-neutral-800 px-3 py-3 pr-10 text-sm focus:border-[var(--primary-500)] focus:ring-[var(--primary-500)]"/>
+          <button type="button" id="togglePassword" class="absolute inset-y-0 right-0 flex items-center pr-3 text-sm text-neutral-400 hover:text-neutral-200">Show</button>
+        </div>
+        <div class="mt-1 text-right">
+          <a href="#" class="text-sm text-[var(--primary-500)] hover:underline">Forgot Password?</a>
+        </div>
+      </div>
+      <button type="submit" class="w-full rounded-md bg-[var(--primary-500)] px-4 py-3 text-lg font-semibold text-white hover:bg-[var(--primary-600)]">Sign In</button>
+    </form>
+    <button id="offlineBtn" class="mt-6 text-sm font-medium text-neutral-300 underline disabled:no-underline disabled:opacity-50" title="Work offline with last synced data" disabled>Enter Offline Mode</button>
+  </main>
+
+  <footer class="flex items-center justify-between p-4 text-xs">
+    <span id="version"></span>
+    <div id="connectionStatus" class="flex items-center gap-1">
+      <span class="status-dot h-2 w-2 rounded-full"></span>
+      <span class="status-text"></span>
+    </div>
+  </footer>
+
+  <script type="module" src="./login.js"></script>
+</body>
+</html>

--- a/src/renderer/login.js
+++ b/src/renderer/login.js
@@ -1,0 +1,38 @@
+import { loadTheme, setupThemeToggle } from './theme.js';
+import { initConnectionStatus } from './connection.js';
+
+loadTheme();
+setupThemeToggle(document.getElementById('themeToggle'));
+initConnectionStatus(document.getElementById('connectionStatus'));
+
+const versionEl = document.getElementById('version');
+versionEl.textContent = `v${window.appInfo?.version || '1.0.0'}`;
+
+const offlineBtn = document.getElementById('offlineBtn');
+const registered = localStorage.getItem('deviceRegistered') === 'true';
+offlineBtn.disabled = !registered;
+
+offlineBtn.addEventListener('click', () => {
+  document.body.classList.add('opacity-0');
+  setTimeout(() => {
+    window.location.href = 'index.html';
+  }, 300);
+});
+
+const form = document.getElementById('loginForm');
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  localStorage.setItem('deviceRegistered', 'true');
+  document.body.classList.add('opacity-0');
+  setTimeout(() => {
+    window.location.href = 'account.html';
+  }, 300);
+});
+
+const togglePassword = document.getElementById('togglePassword');
+const passwordInput = document.getElementById('password');
+togglePassword.addEventListener('click', () => {
+  const isHidden = passwordInput.type === 'password';
+  passwordInput.type = isHidden ? 'text' : 'password';
+  togglePassword.textContent = isHidden ? 'Hide' : 'Show';
+});

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1,7 +1,35 @@
+import { loadTheme, setupThemeToggle } from './theme.js';
 // --- Simple in-memory state ---
 const TAX_RATE = 0.07; // 7%
 let carts = [];
 let activeCartIndex = 0;
+const STORAGE_KEY = 'retailpro_carts';
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const data = JSON.parse(raw);
+      if (Array.isArray(data.carts)) {
+        carts = data.carts;
+        activeCartIndex = data.activeCartIndex || 0;
+      }
+    }
+  } catch (err) {
+    console.error('Failed to load state', err);
+  }
+}
+
+function saveState() {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ carts, activeCartIndex })
+    );
+  } catch (err) {
+    console.error('Failed to save state', err);
+  }
+}
 
 // Demo products
 const PRODUCTS = [
@@ -29,6 +57,7 @@ const cartItemsEl = document.getElementById('cartItems');
 const totalsEl = document.getElementById('totals');
 const searchInput = document.getElementById('searchInput');
 const categoryFilter = document.getElementById('categoryFilter');
+const themeToggle = document.getElementById('themeToggle');
 
 // --- Helpers ---
 const money = (n) => `$${n.toFixed(2)}`;
@@ -46,6 +75,7 @@ function setActiveCart(index) {
   activeCartIndex = index;
   renderTabs();
   renderCart();
+  saveState();
 }
 
 function addNewCart() {
@@ -58,6 +88,7 @@ function addToCart(productId, qty = 1) {
   cart.items[productId] = (cart.items[productId] || 0) + qty;
   renderCart();
   renderTabs();
+  saveState();
 }
 
 function updateQty(productId, qty) {
@@ -66,6 +97,7 @@ function updateQty(productId, qty) {
   else cart.items[productId] = qty;
   renderCart();
   renderTabs();
+  saveState();
 }
 
 function removeFromCart(productId) {
@@ -73,6 +105,7 @@ function removeFromCart(productId) {
   delete cart.items[productId];
   renderCart();
   renderTabs();
+  saveState();
 }
 
 function calcTotals(cart) {
@@ -197,9 +230,13 @@ function renderCart() {
 // --- Events ---
 searchInput.addEventListener('input', renderProducts);
 categoryFilter.addEventListener('change', renderProducts);
+setupThemeToggle(themeToggle);
 
 // --- Init ---
+loadTheme();
+loadState();
 ensureAtLeastOneCart();
 renderTabs();
 renderProducts();
 renderCart();
+saveState();

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1,0 +1,40 @@
+:root {
+  --primary-500:#3d99f5; --primary-600:#258af3; --neutral-50:#f8fafc; --neutral-100:#f1f5f9;
+  --neutral-200:#e2e8f0; --neutral-300:#cbd5e1; --neutral-400:#94a3b8; --neutral-600:#475569;
+  --neutral-700:#334155; --neutral-800:#1e293b; --neutral-900:#0f172a;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  transition: opacity .3s;
+}
+
+input[type=number]::-webkit-outer-spin-button,
+input[type=number]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type=number] { -moz-appearance: textfield; }
+
+body.light { background-color: var(--neutral-50); color: var(--neutral-900); }
+body.light .bg-neutral-900 { background-color: var(--neutral-50); }
+body.light .text-neutral-200 { color: var(--neutral-800); }
+body.light .border-neutral-800 { border-color: var(--neutral-200); }
+body.light .bg-neutral-800 { background-color: var(--neutral-100); }
+body.light .text-neutral-400 { color: var(--neutral-600); }
+body.light .border-neutral-700 { border-color: var(--neutral-300); }
+body.light .text-neutral-300 { color: var(--neutral-700); }
+body.light .bg-neutral-700 { background-color: var(--neutral-200); }
+body.light .bg-neutral-700\/50 { background-color: rgb(226 232 240 / 0.5); }
+body.light .bg-blue-900\/50 { background-color: rgb(191 219 254); }
+body.light .hover\:bg-neutral-700\/50:hover { background-color: rgb(226 232 240 / 0.5); }
+body.light .border-neutral-600 { border-color: var(--neutral-400); }
+body.light .bg-neutral-600 { background-color: var(--neutral-300); }
+body.light .text-neutral-100 { color: var(--neutral-900); }
+body.light .hover\:bg-neutral-800:hover { background-color: var(--neutral-100); }
+body.light .hover\:bg-neutral-700:hover { background-color: var(--neutral-200); }
+body.light .hover\:bg-neutral-600:hover { background-color: var(--neutral-300); }
+body.light .hover\:text-neutral-300:hover { color: var(--neutral-700); }
+body.light .hover\:border-neutral-600:hover { border-color: var(--neutral-400); }
+body.light .ring-neutral-800 { --tw-ring-color: var(--neutral-200); }
+body.light .ring-neutral-700 { --tw-ring-color: var(--neutral-300); }

--- a/src/renderer/theme.js
+++ b/src/renderer/theme.js
@@ -1,0 +1,30 @@
+export const THEME_KEY = 'retailpro_theme';
+
+export function applyTheme(theme) {
+  document.body.classList.toggle('light', theme === 'light');
+  const icon = document.getElementById('themeIcon');
+  if (icon) icon.textContent = theme === 'light' ? '🌞' : '🌙';
+  try {
+    localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function loadTheme() {
+  let theme = 'dark';
+  try {
+    theme = localStorage.getItem(THEME_KEY) || 'dark';
+  } catch {
+    /* ignore */
+  }
+  applyTheme(theme);
+}
+
+export function setupThemeToggle(button) {
+  if (!button) return;
+  button.addEventListener('click', () => {
+    const isLight = document.body.classList.contains('light');
+    applyTheme(isLight ? 'dark' : 'light');
+  });
+}


### PR DESCRIPTION
## Summary
- add dedicated login and account selection pages with offline mode, connection status, and theme toggle
- refactor theme handling into reusable module and expose app version via preload
- start app at login screen to transition into existing POS interface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1883ab348330b9d1a51e38f51825