### PR TITLE
Add login and account selection screen

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -8,44 +8,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
-  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-  <style type="text/tailwindcss">
-    :root {
-      --primary-500:#3d99f5; --primary-600:#258af3; --neutral-50:#f8fafc; --neutral-100:#f1f5f9;
-      --neutral-200:#e2e8f0; --neutral-300:#cbd5e1; --neutral-400:#94a3b8; --neutral-600:#475569;
-      --neutral-700:#334155; --neutral-800:#1e293b; --neutral-900:#0f172a;
-    }
-    body { font-family: 'Inter', sans-serif; }
-    input[type=number]::-webkit-outer-spin-button,
-  input[type=number]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-  input[type=number] { -moz-appearance: textfield; }
-  </style>
-  <style>
-    body.light { background-color: var(--neutral-50); color: var(--neutral-900); }
-    body.light .bg-neutral-900 { background-color: var(--neutral-50); }
-    body.light .text-neutral-200 { color: var(--neutral-800); }
-    body.light .border-neutral-800 { border-color: var(--neutral-200); }
-    body.light .bg-neutral-800 { background-color: var(--neutral-100); }
-    body.light .text-neutral-400 { color: var(--neutral-600); }
-    body.light .border-neutral-700 { border-color: var(--neutral-300); }
-    body.light .text-neutral-300 { color: var(--neutral-700); }
-    body.light .bg-neutral-700 { background-color: var(--neutral-200); }
-    body.light .bg-neutral-700\/50 { background-color: rgb(226 232 240 / 0.5); }
-    body.light .bg-blue-900\/50 { background-color: rgb(191 219 254); }
-    body.light .hover\:bg-neutral-700\/50:hover { background-color: rgb(226 232 240 / 0.5); }
-    body.light .border-neutral-600 { border-color: var(--neutral-400); }
-    body.light .bg-neutral-600 { background-color: var(--neutral-300); }
-    body.light .text-neutral-100 { color: var(--neutral-900); }
-    body.light .hover\:bg-neutral-800:hover { background-color: var(--neutral-100); }
-    body.light .hover\:bg-neutral-700:hover { background-color: var(--neutral-200); }
-    body.light .hover\:bg-neutral-600:hover { background-color: var(--neutral-300); }
-    body.light .hover\:text-neutral-300:hover { color: var(--neutral-700); }
-    body.light .hover\:border-neutral-600:hover { border-color: var(--neutral-400); }
-    body.light .ring-neutral-800 { --tw-ring-color: var(--neutral-200); }
-    body.light .ring-neutral-700 { --tw-ring-color: var(--neutral-300); }
-  </style>
-</head>
-<body class="bg-neutral-900 text-neutral-200">
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link rel="stylesheet" href="./theme.css" />
+  </head>
+  <body class="bg-neutral-900 text-neutral-200">
 <div class="flex h-screen w-full flex-col">
   <!-- Header -->
   <header class="flex items-center justify-between border-b border-neutral-800 px-6 py-3">
@@ -177,6 +143,7 @@
   </footer>
 </div>
 
-<script src="./renderer.js"></script>
-</body>
-</html>
+  <script src="./theme.js"></script>
+  <script src="./renderer.js"></script>
+  </body>
+  </html>

--- a/src/renderer/login.html
+++ b/src/renderer/login.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login – RetailPro</title>
+  <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64,">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <link rel="stylesheet" href="./theme.css" />
+</head>
+<body class="bg-neutral-900 text-neutral-200">
+<div class="flex min-h-screen flex-col">
+  <!-- Header -->
+  <header class="flex items-center justify-between border-b border-neutral-800 px-6 py-3">
+    <div class="flex items-center gap-3">
+      <div class="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--primary-500)] text-white">
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+          <path d="M8.57829 8.57829C5.52816 11.6284 3.451 15.5145 2.60947 19.7452C1.76794 23.9758 2.19984 28.361 3.85056 32.3462C5.50128 36.3314 8.29667 39.7376 11.8832 42.134C15.4698 44.5305 19.6865 45.8096 24 45.8096C28.3135 45.8096 32.5302 44.5305 36.1168 42.134C39.7033 39.7375 42.4987 36.3314 44.1494 32.3462C45.8002 28.361 46.2321 23.9758 45.3905 19.7452C44.549 15.5145 42.4718 11.6284 39.4217 8.57829L24 24L8.57829 8.57829Z" fill="currentColor"></path>
+        </svg>
+      </div>
+      <h1 class="text-xl font-bold text-neutral-100">RetailPro</h1>
+    </div>
+    <button id="themeToggle" class="rounded-full p-2 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-300" title="Toggle theme">
+      <span id="themeIcon" class="block h-5 w-5">🌙</span>
+    </button>
+  </header>
+
+  <!-- Main content -->
+  <main class="flex flex-1 flex-col items-center justify-center px-4 py-8">
+    <!-- Login -->
+    <div id="loginContainer" class="w-full max-w-sm space-y-4 transition-opacity">
+      <div>
+        <label for="email" class="mb-1 block text-sm font-medium">Email or Phone</label>
+        <input id="email" type="text" class="block w-full rounded-md border-neutral-700 bg-neutral-800 px-3 py-3 text-base placeholder:text-neutral-500 focus:border-[var(--primary-500)] focus:ring-[var(--primary-500)]" placeholder="you@example.com" />
+      </div>
+      <div>
+        <label for="password" class="mb-1 block text-sm font-medium">Password</label>
+        <div class="relative">
+          <input id="password" type="password" class="block w-full rounded-md border-neutral-700 bg-neutral-800 px-3 py-3 text-base placeholder:text-neutral-500 focus:border-[var(--primary-500)] focus:ring-[var(--primary-500)]" />
+          <button id="togglePassword" type="button" class="absolute inset-y-0 right-0 px-3 text-sm text-neutral-400">Show</button>
+        </div>
+        <a href="#" class="mt-1 inline-block text-sm text-[var(--primary-500)] hover:underline">Forgot Password?</a>
+      </div>
+      <button id="signInBtn" class="mt-2 w-full rounded-md bg-[var(--primary-500)] px-4 py-3 text-lg font-semibold text-white hover:bg-[var(--primary-600)]">Sign In</button>
+      <button id="offlineBtn" class="w-full rounded-md border border-neutral-700 bg-neutral-800 px-4 py-3 text-sm font-medium text-neutral-200 hover:bg-neutral-700 disabled:opacity-50" title="Work offline with last synced data" disabled>Enter Offline Mode</button>
+    </div>
+
+    <!-- Account selection -->
+    <div id="accountContainer" class="hidden w-full max-w-lg space-y-4 opacity-0 transition-opacity">
+      <h2 class="text-center text-xl font-semibold text-neutral-100">Select Store / Desk</h2>
+      <div id="accountList" class="space-y-3">
+        <button class="w-full rounded-md bg-neutral-800 px-4 py-4 text-neutral-100 hover:bg-neutral-700">Main Street - Register 1</button>
+        <button class="w-full rounded-md bg-neutral-800 px-4 py-4 text-neutral-100 hover:bg-neutral-700">Mall Kiosk - Register 2</button>
+        <button class="w-full rounded-md bg-neutral-800 px-4 py-4 text-neutral-100 hover:bg-neutral-700">Outlet - Register 3</button>
+      </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="flex items-center justify-between border-t border-neutral-800 px-6 py-2 text-sm">
+    <span id="version">v1.0.0</span>
+    <div id="connectionStatus" class="flex items-center gap-2">
+      <span id="statusDot" class="h-2 w-2 rounded-full bg-green-500"></span>
+      <span id="statusText">Online</span>
+    </div>
+  </footer>
+</div>
+<script src="./theme.js"></script>
+<script src="./login.js"></script>
+</body>
+</html>

--- a/src/renderer/login.js
+++ b/src/renderer/login.js
@@ -1,0 +1,48 @@
+document.addEventListener('DOMContentLoaded', () => {
+  loadTheme();
+
+  const themeToggle = document.getElementById('themeToggle');
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const isLight = document.body.classList.contains('light');
+      applyTheme(isLight ? 'dark' : 'light');
+    });
+  }
+
+  const password = document.getElementById('password');
+  const togglePassword = document.getElementById('togglePassword');
+  togglePassword.addEventListener('click', () => {
+    const isHidden = password.type === 'password';
+    password.type = isHidden ? 'text' : 'password';
+    togglePassword.textContent = isHidden ? 'Hide' : 'Show';
+  });
+
+  const signInBtn = document.getElementById('signInBtn');
+  const loginContainer = document.getElementById('loginContainer');
+  const accountContainer = document.getElementById('accountContainer');
+  signInBtn.addEventListener('click', () => {
+    loginContainer.classList.add('opacity-0');
+    setTimeout(() => {
+      loginContainer.classList.add('hidden');
+      accountContainer.classList.remove('hidden');
+      setTimeout(() => accountContainer.classList.remove('opacity-0'), 50);
+    }, 300);
+  });
+
+  const offlineBtn = document.getElementById('offlineBtn');
+  const deviceRegistered = false; // Replace with real check
+  if (deviceRegistered) offlineBtn.disabled = false;
+
+  function updateStatus() {
+    const online = navigator.onLine;
+    const dot = document.getElementById('statusDot');
+    const text = document.getElementById('statusText');
+    dot.classList.toggle('bg-green-500', online);
+    dot.classList.toggle('bg-red-500', !online);
+    text.textContent = online ? 'Online' : 'Offline';
+  }
+
+  window.addEventListener('online', updateStatus);
+  window.addEventListener('offline', updateStatus);
+  updateStatus();
+});

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -3,7 +3,6 @@ const TAX_RATE = 0.07; // 7%
 let carts = [];
 let activeCartIndex = 0;
 const STORAGE_KEY = 'retailpro_carts';
-const THEME_KEY = 'retailpro_theme';
 
 function loadState() {
   try {
@@ -31,26 +30,6 @@ function saveState() {
   }
 }
 
-function applyTheme(theme) {
-  document.body.classList.toggle('light', theme === 'light');
-  const icon = document.getElementById('themeIcon');
-  if (icon) icon.textContent = theme === 'light' ? '🌞' : '🌙';
-  try {
-    localStorage.setItem(THEME_KEY, theme);
-  } catch (err) {
-    console.error('Failed to save theme', err);
-  }
-}
-
-function loadTheme() {
-  let theme = 'dark';
-  try {
-    theme = localStorage.getItem(THEME_KEY) || 'dark';
-  } catch (err) {
-    console.error('Failed to load theme', err);
-  }
-  applyTheme(theme);
-}
 
 // Demo products
 const PRODUCTS = [

--- a/src/renderer/theme.css
+++ b/src/renderer/theme.css
@@ -1,0 +1,43 @@
+:root {
+  --primary-500:#3d99f5;
+  --primary-600:#258af3;
+  --neutral-50:#f8fafc;
+  --neutral-100:#f1f5f9;
+  --neutral-200:#e2e8f0;
+  --neutral-300:#cbd5e1;
+  --neutral-400:#94a3b8;
+  --neutral-600:#475569;
+  --neutral-700:#334155;
+  --neutral-800:#1e293b;
+  --neutral-900:#0f172a;
+}
+
+body { font-family: 'Inter', sans-serif; }
+
+input[type=number]::-webkit-outer-spin-button,
+input[type=number]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+input[type=number] { -moz-appearance: textfield; }
+
+/* Light mode overrides */
+body.light { background-color: var(--neutral-50); color: var(--neutral-900); }
+body.light .bg-neutral-900 { background-color: var(--neutral-50); }
+body.light .text-neutral-200 { color: var(--neutral-800); }
+body.light .border-neutral-800 { border-color: var(--neutral-200); }
+body.light .bg-neutral-800 { background-color: var(--neutral-100); }
+body.light .text-neutral-400 { color: var(--neutral-600); }
+body.light .border-neutral-700 { border-color: var(--neutral-300); }
+body.light .text-neutral-300 { color: var(--neutral-700); }
+body.light .bg-neutral-700 { background-color: var(--neutral-200); }
+body.light .bg-neutral-700\/50 { background-color: rgb(226 232 240 / 0.5); }
+body.light .bg-blue-900\/50 { background-color: rgb(191 219 254); }
+body.light .hover\:bg-neutral-700\/50:hover { background-color: rgb(226 232 240 / 0.5); }
+body.light .border-neutral-600 { border-color: var(--neutral-400); }
+body.light .bg-neutral-600 { background-color: var(--neutral-300); }
+body.light .text-neutral-100 { color: var(--neutral-900); }
+body.light .hover\:bg-neutral-800:hover { background-color: var(--neutral-100); }
+body.light .hover\:bg-neutral-700:hover { background-color: var(--neutral-200); }
+body.light .hover\:bg-neutral-600:hover { background-color: var(--neutral-300); }
+body.light .hover\:text-neutral-300:hover { color: var(--neutral-700); }
+body.light .hover\:border-neutral-600:hover { border-color: var(--neutral-400); }
+body.light .ring-neutral-800 { --tw-ring-color: var(--neutral-200); }
+body.light .ring-neutral-700 { --tw-ring-color: var(--neutral-300); }

--- a/src/renderer/theme.js
+++ b/src/renderer/theme.js
@@ -1,0 +1,25 @@
+const THEME_KEY = 'retailpro_theme';
+
+function applyTheme(theme) {
+  document.body.classList.toggle('light', theme === 'light');
+  const icon = document.getElementById('themeIcon');
+  if (icon) icon.textContent = theme === 'light' ? '🌞' : '🌙';
+  try {
+    localStorage.setItem(THEME_KEY, theme);
+  } catch (err) {
+    console.error('Failed to save theme', err);
+  }
+}
+
+function loadTheme() {
+  let theme = 'dark';
+  try {
+    theme = localStorage.getItem(THEME_KEY) || 'dark';
+  } catch (err) {
+    console.error('Failed to load theme', err);
+  }
+  applyTheme(theme);
+}
+
+window.applyTheme = applyTheme;
+window.loadTheme = loadTheme;


### PR DESCRIPTION
## Summary
- Add Tailwind-based login and account selection screens with offline entry and connection status
- Centralize theme styles and logic for reuse across screens
- Integrate shared theme loader into existing POS interface

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689b92fad7088330858fd1d323cda658